### PR TITLE
fix: add --exclusive option to the deployment

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,11 @@
+{
+    "files.exclude": {
+        "**/.git": true,
+        "**/.svn": true,
+        "**/.hg": true,
+        "**/CVS": true,
+        "**/.DS_Store": true,
+        "**/Thumbs.db": true,
+        "**/node_modules": true
+    }
+}

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -213,7 +213,11 @@ export class GitHubWorkflow extends PipelineBase {
     this.runner = props.runner ?? github.Runner.UBUNTU_LATEST;
     this.buildRunner = props.buildRunner ?? this.runner;
 
+    /** By default, deploy! */
     this.deployArgs.push(`--require-approval=${props.requireApproval ?? 'never'}`);
+
+    /** The pipeline handles dependency ordering, no need to re-deploy dependency stacks */
+    this.deployArgs.push('--exclusively');
   }
 
   /**

--- a/test/__snapshots__/github.test.ts.snap
+++ b/test/__snapshots__/github.test.ts.snap
@@ -83,7 +83,7 @@ jobs:
           aws-secret-access-key: \${{ secrets.AWS_SECRET_ACCESS_KEY }}
       - id: Deploy
         run: npx cdk --app /tmp/exampleApp.out deploy StageA/BucketStack
-          --require-approval=never
+          --require-approval=never --exclusively
   StageA-FunctionStack-Deploy:
     name: Deploy StageA/FunctionStack
     permissions:
@@ -111,7 +111,7 @@ jobs:
           aws-secret-access-key: \${{ secrets.AWS_SECRET_ACCESS_KEY }}
       - id: Deploy
         run: npx cdk --app /tmp/exampleApp.out deploy StageA/FunctionStack
-          --require-approval=never
+          --require-approval=never --exclusively
     outputs:
       myout: \${{ steps.Deploy.outputs.myout }}
   StageA-Post:
@@ -157,7 +157,7 @@ jobs:
           aws-secret-access-key: \${{ secrets.AWS_SECRET_ACCESS_KEY }}
       - id: Deploy
         run: npx cdk --app /tmp/exampleApp.out deploy StageB/BucketStack
-          --require-approval=never
+          --require-approval=never --exclusively
   StageB-FunctionStack-Deploy:
     name: Deploy StageB/FunctionStack
     permissions:
@@ -188,7 +188,7 @@ jobs:
           aws-secret-access-key: \${{ secrets.AWS_SECRET_ACCESS_KEY }}
       - id: Deploy
         run: npx cdk --app /tmp/exampleApp.out deploy StageB/FunctionStack
-          --require-approval=never
+          --require-approval=never --exclusively
 "
 `;
 
@@ -389,6 +389,7 @@ jobs:
           aws-session-token: \${{ secrets.MY_SESSION_TOKEN }}
       - id: Deploy
         run: npx cdk --app github.out deploy MyStack/MyStack --require-approval=never
+          --exclusively
 "
 `;
 
@@ -460,6 +461,7 @@ jobs:
           role-session-name: my-github-actions-session
       - id: Deploy
         run: npx cdk --app github.out deploy MyStack/MyStack --require-approval=never
+          --exclusively
 "
 `;
 
@@ -531,6 +533,7 @@ jobs:
           aws-secret-access-key: \${{ secrets.AWS_SECRET_ACCESS_KEY }}
       - id: Deploy
         run: npx cdk --app github.out deploy MyStack/MyStack --require-approval=never
+          --exclusively
 "
 `;
 
@@ -638,6 +641,7 @@ jobs:
           aws-secret-access-key: \${{ secrets.AWS_SECRET_ACCESS_KEY }}
       - id: Deploy
         run: npx cdk --app github.out deploy MyStack/MyStack --require-approval=never
+          --exclusively
 "
 `;
 
@@ -758,6 +762,7 @@ jobs:
         run: npx cdk --app github.out diff MyStack/MyStack
       - id: Deploy
         run: npx cdk --app github.out deploy MyStack/MyStack --require-approval=never
+          --exclusively
 "
 `;
 
@@ -827,5 +832,6 @@ jobs:
           aws-secret-access-key: \${{ secrets.AWS_SECRET_ACCESS_KEY }}
       - id: Deploy
         run: npx cdk --app github.out deploy MyStack/MyStack --require-approval=never
+          --exclusively
 "
 `;

--- a/test/__snapshots__/runner-provided.test.ts.snap
+++ b/test/__snapshots__/runner-provided.test.ts.snap
@@ -52,6 +52,6 @@ jobs:
         run: tar -zxf cdk.out.tgz
       - id: Deploy
         run: npx cdk --app runner-provided.out deploy MyStack/MyStack
-          --require-approval=never
+          --require-approval=never --exclusively
 "
 `;

--- a/test/__snapshots__/stage-options.test.ts.snap
+++ b/test/__snapshots__/stage-options.test.ts.snap
@@ -86,7 +86,7 @@ jobs:
           aws-secret-access-key: \${{ secrets.AWS_SECRET_ACCESS_KEY }}
       - id: Deploy
         run: npx cdk --app stage.out deploy MyPrePostStack/MyStack
-          --require-approval=never
+          --require-approval=never --exclusively
   MyPrePostStack-PostDeployAction:
     name: PostDeployAction
     if: contains(fromJson('[\\"push\\", \\"pull_request\\"]'), github.event_name)
@@ -176,6 +176,7 @@ jobs:
           aws-secret-access-key: \${{ secrets.AWS_SECRET_ACCESS_KEY }}
       - id: Deploy
         run: npx cdk --app stage.out deploy MyStack/MyStack --require-approval=never
+          --exclusively
 "
 `;
 
@@ -247,6 +248,7 @@ jobs:
           aws-secret-access-key: \${{ secrets.AWS_SECRET_ACCESS_KEY }}
       - id: Deploy
         run: npx cdk --app stage.out deploy MyStack/MyStack --require-approval=never
+          --exclusively
 "
 `;
 
@@ -319,6 +321,7 @@ jobs:
           aws-secret-access-key: \${{ secrets.AWS_SECRET_ACCESS_KEY }}
       - id: Deploy
         run: npx cdk --app stage.out deploy MyStage1/MyStack --require-approval=never
+          --exclusively
   MyStage2-MyStack-Deploy:
     name: Deploy MyStage2/MyStack
     permissions:
@@ -346,6 +349,7 @@ jobs:
           aws-secret-access-key: \${{ secrets.AWS_SECRET_ACCESS_KEY }}
       - id: Deploy
         run: npx cdk --app stage.out deploy MyStage2/MyStack --require-approval=never
+          --exclusively
 "
 `;
 
@@ -437,6 +441,7 @@ jobs:
           aws-secret-access-key: \${{ secrets.AWS_SECRET_ACCESS_KEY }}
       - id: Deploy
         run: npx cdk --app stage.out deploy MyStageA/MyStackA --require-approval=never
+          --exclusively
   MyWave-MyStageB-MyStackB-Deploy:
     name: Deploy MyStageB/MyStackB
     if: success() && contains(github.event.issue.labels.*.name, 'deployToB')
@@ -464,6 +469,7 @@ jobs:
           aws-secret-access-key: \${{ secrets.AWS_SECRET_ACCESS_KEY }}
       - id: Deploy
         run: npx cdk --app stage.out deploy MyStageB/MyStackB --require-approval=never
+          --exclusively
   MyWave-PostWaveAction:
     name: PostWaveAction
     if: contains(github.event.issue.labels.*.name, 'deployToA') ||
@@ -556,6 +562,7 @@ jobs:
           aws-secret-access-key: \${{ secrets.AWS_SECRET_ACCESS_KEY }}
       - id: Deploy
         run: npx cdk --app stage.out deploy MyStack/MyStack --require-approval=never
+          --exclusively
 "
 `;
 
@@ -628,6 +635,7 @@ jobs:
           aws-secret-access-key: \${{ secrets.AWS_SECRET_ACCESS_KEY }}
       - id: Deploy
         run: npx cdk --app stage.out deploy MyStageA/MyStackA --require-approval=never
+          --exclusively
   MyWave-MyStageB-MyStackB-Deploy:
     name: Deploy MyStageB/MyStackB
     if: success() && contains(github.event.issue.labels.*.name, 'deployToB')
@@ -654,6 +662,7 @@ jobs:
           aws-secret-access-key: \${{ secrets.AWS_SECRET_ACCESS_KEY }}
       - id: Deploy
         run: npx cdk --app stage.out deploy MyStageB/MyStackB --require-approval=never
+          --exclusively
 "
 `;
 
@@ -726,6 +735,7 @@ jobs:
           aws-secret-access-key: \${{ secrets.AWS_SECRET_ACCESS_KEY }}
       - id: Deploy
         run: npx cdk --app stage.out deploy MyStageA/MyStackA --require-approval=never
+          --exclusively
   MyStageB-MyStackB-Deploy:
     name: Deploy MyStageB/MyStackB
     if: success() && contains(github.event.issue.labels.*.name, 'deployToB')
@@ -753,5 +763,6 @@ jobs:
           aws-secret-access-key: \${{ secrets.AWS_SECRET_ACCESS_KEY }}
       - id: Deploy
         run: npx cdk --app stage.out deploy MyStageB/MyStackB --require-approval=never
+          --exclusively
 "
 `;


### PR DESCRIPTION
When building pipelines, the pipelines themselves handle the ordering of resource deps... so we don't need to _re-run_ the deploy to a stack that is a dependency of a current stack, we can trust that it was deployed already.