### PR TITLE
chore(deps): remove pinned constructsVersion

### DIFF
--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -132,7 +132,7 @@
     },
     {
       "name": "constructs",
-      "version": "^10.0.46",
+      "version": "^10.0.5",
       "type": "peer"
     }
   ],

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -11,7 +11,6 @@ const project = new AwsCdkConstructLibrary({
   authorAddress: 'aws-cdk-dev@amazon.com',
   cdkVersion: '2.9.0',
   jsiiVersion: '^5.3.0',
-  constructsVersion: '10.0.46',
   defaultReleaseBranch: 'nextdoor',
   repositoryUrl: 'https://github.com/Nextdoor/cdk-pipelines-github.git',
   bundledDeps: ['decamelize', 'yaml', 'fast-json-patch'],

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@typescript-eslint/parser": "^6",
     "aws-cdk-lib": "2.9.0",
     "cdklabs-projen-project-types": "^0.1.163",
-    "constructs": "10.0.46",
+    "constructs": "10.0.5",
     "eslint": "^8",
     "eslint-config-prettier": "^9.0.0",
     "eslint-import-resolver-typescript": "^3.6.1",
@@ -65,7 +65,7 @@
   },
   "peerDependencies": {
     "aws-cdk-lib": "^2.9.0",
-    "constructs": "^10.0.46"
+    "constructs": "^10.0.5"
   },
   "dependencies": {
     "decamelize": "5.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1526,10 +1526,10 @@ concat-stream@^2.0.0:
     readable-stream "^3.0.2"
     typedarray "^0.0.6"
 
-constructs@10.0.46:
-  version "10.0.46"
-  resolved "https://registry.yarnpkg.com/constructs/-/constructs-10.0.46.tgz#0f13d1c2c0b461df9ebeee3d901630b63daff750"
-  integrity sha512-Dxc1TlYRJbdJfQEYwx8vO+ns1EpUpVko4a6UJ6htZ0UvV4YLXkjTY/QMpM+rfUWgPDtXp5xxi+vQZcbFHmUHEw==
+constructs@10.0.5:
+  version "10.0.5"
+  resolved "https://registry.yarnpkg.com/constructs/-/constructs-10.0.5.tgz#48c0402f1b98bbf5664efff74a8015e6e8a9f41e"
+  integrity sha512-IwOwekzrASFC3qt4ozCtV09rteAIAesuCGsW0p+uBfqHd2XcvA5CXqJjgf4eUqm6g8e/noXlVCMDWwC8GaLtrg==
 
 constructs@^10.0.0:
   version "10.3.0"


### PR DESCRIPTION
I believe this should make it easier to use this library without having to match the minimum version in other libraries.