### PR TITLE
chore(ci): upgrade upload-artifact action version

### DIFF
--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -671,7 +671,7 @@ export class GitHubWorkflow extends PipelineBase {
     return [
       {
         name: `Upload ${name}`,
-        uses: 'actions/upload-artifact@v3',
+        uses: 'actions/upload-artifact@v4',
         with: {
           name: name,
           path: sourcePath,

--- a/test/__snapshots__/github.test.ts.snap
+++ b/test/__snapshots__/github.test.ts.snap
@@ -41,7 +41,7 @@ jobs:
       - name: Package cdk.out
         run: tar -zcf cdk.out.tgz /tmp/exampleApp.out
       - name: Upload cdk.out
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: cdk.out
           path: cdk.out.tgz
@@ -229,7 +229,7 @@ jobs:
       - name: Package cdk.out
         run: tar -zcf cdk.out.tgz github.out
       - name: Upload cdk.out
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: cdk.out
           path: cdk.out.tgz
@@ -269,7 +269,7 @@ jobs:
       - name: Package cdk.out
         run: tar -zcf cdk.out.tgz github.out
       - name: Upload cdk.out
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: cdk.out
           path: cdk.out.tgz
@@ -310,7 +310,7 @@ jobs:
       - name: Package cdk.out
         run: tar -zcf cdk.out.tgz github.out
       - name: Upload cdk.out
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: cdk.out
           path: cdk.out.tgz
@@ -357,7 +357,7 @@ jobs:
       - name: Package cdk.out
         run: tar -zcf cdk.out.tgz github.out
       - name: Upload cdk.out
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: cdk.out
           path: cdk.out.tgz
@@ -430,7 +430,7 @@ jobs:
       - name: Package cdk.out
         run: tar -zcf cdk.out.tgz github.out
       - name: Upload cdk.out
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: cdk.out
           path: cdk.out.tgz
@@ -501,7 +501,7 @@ jobs:
       - name: Package cdk.out
         run: tar -zcf cdk.out.tgz github.out
       - name: Upload cdk.out
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: cdk.out
           path: cdk.out.tgz
@@ -566,7 +566,7 @@ jobs:
       - name: Package cdk.out
         run: tar -zcf cdk.out.tgz github.out
       - name: Upload cdk.out
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: cdk.out
           path: cdk.out.tgz
@@ -610,7 +610,7 @@ jobs:
       - name: Package cdk.out
         run: tar -zcf cdk.out.tgz github.out
       - name: Upload cdk.out
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: cdk.out
           path: cdk.out.tgz
@@ -685,7 +685,7 @@ jobs:
       - name: Package cdk.out
         run: tar -zcf cdk.out.tgz github.out
       - name: Upload cdk.out
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: cdk.out
           path: cdk.out.tgz
@@ -729,7 +729,7 @@ jobs:
       - name: Package cdk.out
         run: tar -zcf cdk.out.tgz github.out
       - name: Upload cdk.out
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: cdk.out
           path: cdk.out.tgz
@@ -801,7 +801,7 @@ jobs:
       - name: Package cdk.out
         run: tar -zcf cdk.out.tgz github.out
       - name: Upload cdk.out
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: cdk.out
           path: cdk.out.tgz

--- a/test/__snapshots__/runner-provided.test.ts.snap
+++ b/test/__snapshots__/runner-provided.test.ts.snap
@@ -29,7 +29,7 @@ jobs:
       - name: Package cdk.out
         run: tar -zcf cdk.out.tgz runner-provided.out
       - name: Upload cdk.out
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: cdk.out
           path: cdk.out.tgz

--- a/test/__snapshots__/stage-options.test.ts.snap
+++ b/test/__snapshots__/stage-options.test.ts.snap
@@ -38,7 +38,7 @@ jobs:
       - name: Package cdk.out
         run: tar -zcf cdk.out.tgz stage.out
       - name: Upload cdk.out
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: cdk.out
           path: cdk.out.tgz
@@ -145,7 +145,7 @@ jobs:
       - name: Package cdk.out
         run: tar -zcf cdk.out.tgz stage.out
       - name: Upload cdk.out
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: cdk.out
           path: cdk.out.tgz
@@ -217,7 +217,7 @@ jobs:
       - name: Package cdk.out
         run: tar -zcf cdk.out.tgz stage.out
       - name: Upload cdk.out
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: cdk.out
           path: cdk.out.tgz
@@ -288,7 +288,7 @@ jobs:
       - name: Package cdk.out
         run: tar -zcf cdk.out.tgz stage.out
       - name: Upload cdk.out
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: cdk.out
           path: cdk.out.tgz
@@ -521,7 +521,7 @@ jobs:
       - name: Package cdk.out
         run: tar -zcf cdk.out.tgz stage.out
       - name: Upload cdk.out
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: cdk.out
           path: cdk.out.tgz
@@ -624,7 +624,7 @@ jobs:
       - name: Package cdk.out
         run: tar -zcf cdk.out.tgz stage.out
       - name: Upload cdk.out
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: cdk.out
           path: cdk.out.tgz
@@ -762,7 +762,7 @@ jobs:
       - name: Package cdk.out
         run: tar -zcf cdk.out.tgz stage.out
       - name: Upload cdk.out
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: cdk.out
           path: cdk.out.tgz
@@ -835,7 +835,7 @@ jobs:
       - name: Package cdk.out
         run: tar -zcf cdk.out.tgz stage.out
       - name: Upload cdk.out
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: cdk.out
           path: cdk.out.tgz
@@ -935,7 +935,7 @@ jobs:
       - name: Package cdk.out
         run: tar -zcf cdk.out.tgz stage.out
       - name: Upload cdk.out
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: cdk.out
           path: cdk.out.tgz


### PR DESCRIPTION
```
Error: This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v3`. Learn more: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/
```

This PR updates upload-artifact version. 